### PR TITLE
`LoadBalancedChannel::builder`

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,7 +41,7 @@ let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(
 
 // Initialise a new gRPC client for the `Test` service
 // using the load-balanced channel as transport
-let grpc_client = TestClient::new(load_balanced_channel);
+let grpc_client = TesterClient::new(load_balanced_channel);
 ```
 
 #### License

--- a/README.md
+++ b/README.md
@@ -28,11 +28,11 @@ tonic's `Channel`.
 
 ```rust
 // Using the `LoadBalancedChannel`.
-use ginepro::{LoadBalancedChannelBuilder, LoadBalancedChannel};
+use ginepro::LoadBalancedChannel;
 use ginepro::pb::tester_client::TesterClient;
 
 // Build a load-balanced channel given a service name and a port.
-let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(
+let load_balanced_channel = LoadBalancedChannel::builder(
     ("my_hostname", 5000)
   )
   .await

--- a/ginepro/examples/client.rs
+++ b/ginepro/examples/client.rs
@@ -1,4 +1,4 @@
-use ginepro::LoadBalancedChannelBuilder;
+use ginepro::LoadBalancedChannel;
 
 use shared_proto::pb::{echo_client::EchoClient, EchoRequest};
 
@@ -6,7 +6,7 @@ use shared_proto::pb::{echo_client::EchoClient, EchoRequest};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a load balanced channel that connects to localhost:5000.
     // Here the service discovery will update the set of servers every 5 seconds.
-    let channel = LoadBalancedChannelBuilder::new_with_service(("localhost", 5000_u16))
+    let channel = LoadBalancedChannel::builder(("localhost", 5000_u16))
         .await?
         .dns_probe_interval(std::time::Duration::from_secs(5))
         .channel();

--- a/ginepro/examples/client_tls.rs
+++ b/ginepro/examples/client_tls.rs
@@ -1,4 +1,4 @@
-use ginepro::LoadBalancedChannelBuilder;
+use ginepro::LoadBalancedChannel;
 use tonic::transport::Certificate;
 use tonic::transport::ClientTlsConfig;
 
@@ -16,7 +16,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let tls = ClientTlsConfig::new().ca_certificate(ca);
 
-    let channel = LoadBalancedChannelBuilder::new_with_service(("localhost", 5000_u16))
+    let channel = LoadBalancedChannel::builder(("localhost", 5000_u16))
         .await?
         .with_tls(tls)
         .dns_probe_interval(std::time::Duration::from_secs(5))

--- a/ginepro/src/lib.rs
+++ b/ginepro/src/lib.rs
@@ -6,16 +6,16 @@
 //! ```rust
 //! #[tokio::main]
 //! async fn main() {
-//!     use ginepro::{LoadBalancedChannel, LoadBalancedChannelBuilder};
+//!     use ginepro::LoadBalancedChannel;
 //!     use shared_proto::pb::tester_client::TesterClient;
 //!
 //!     // Create a load balanced channel with the default lookup implementation.
-//!     let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("my_hostname", 5000))
+//!     let load_balanced_channel = LoadBalancedChannel::builder(("my_hostname", 5000))
 //!         .await
 //!         .expect("failed to read system conf")
 //!         .channel();
 //!
-//!     let tester_client: TesterClient<LoadBalancedChannel> = TesterClient::new(load_balanced_channel);
+//!     let tester_client = TesterClient::new(load_balanced_channel);
 //! }
 //! ```
 //!
@@ -41,16 +41,16 @@
 //!
 //! #[tokio::main]
 //! async fn main() {
-//!     use ginepro::{LoadBalancedChannel, LoadBalancedChannelBuilder};
+//!     use ginepro::LoadBalancedChannel;
 //!     use shared_proto::pb::tester_client::TesterClient;
 //!
-//!     let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("my_hostname", 5000))
+//!     let load_balanced_channel = LoadBalancedChannel::builder(("my_hostname", 5000))
 //!         .await
 //!         .expect("failed to read system conf")
 //!         .lookup_service(DummyLookupService)
 //!         .channel();
 //!
-//!     let tester_client: TesterClient<LoadBalancedChannel> = TesterClient::new(load_balanced_channel);
+//!     let tester_client = TesterClient::new(load_balanced_channel);
 //! }
 //! ```
 //! For systems with lower churn, the probe interval can be lowered.
@@ -67,7 +67,7 @@
 //!         .dns_probe_interval(std::time::Duration::from_secs(3))
 //!         .channel();
 //!
-//!     let tester_client: TesterClient<LoadBalancedChannel> = TesterClient::new(load_balanced_channel);
+//!     let tester_client = TesterClient::new(load_balanced_channel);
 //! }
 //! ```
 //!
@@ -78,16 +78,16 @@
 //! ```rust
 //! #[tokio::main]
 //! async fn main() {
-//!     use ginepro::{LoadBalancedChannel, LoadBalancedChannelBuilder};
+//!     use ginepro::LoadBalancedChannel;
 //!     use shared_proto::pb::tester_client::TesterClient;
 //!
-//!     let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("my_hostname", 5000))
+//!     let load_balanced_channel = LoadBalancedChannel::builder(("my_hostname", 5000))
 //!         .await
 //!         .expect("failed to read system conf")
 //!         .timeout(std::time::Duration::from_secs(10))
 //!         .channel();
 //!
-//!     let tester_client: TesterClient<LoadBalancedChannel> = TesterClient::new(load_balanced_channel);
+//!     let tester_client = TesterClient::new(load_balanced_channel);
 //! }
 //! ```
 //!


### PR DESCRIPTION
Add a `builder` method to allow users to ignore the `LoadBalancedChannelBuilder` type (or, at least, not having to import it directly).
Edit examples to use the new method (and shorten them to avoid a horizontal scrollbar on docs.rs).