### PR TITLE
feat: new LoadBalancedChannelBuilder with LookupService

### DIFF
--- a/ginepro/src/balanced_channel.rs
+++ b/ginepro/src/balanced_channel.rs
@@ -120,6 +120,21 @@ impl LoadBalancedChannelBuilder<DnsResolver> {
 }
 
 impl<T: LookupService + Send + Sync + 'static + Sized> LoadBalancedChannelBuilder<T> {
+    /// Returns a `LoadBalancedChannelBuilder` with the [`ServiceDefinition`] and
+    /// the customized [`LookupService`].
+    pub fn new<H: Into<ServiceDefinition>>(
+        service_definition: H,
+        lookup_service: T,
+    ) -> LoadBalancedChannelBuilder<T> {
+        Self {
+            service_definition: service_definition.into(),
+            probe_interval: None,
+            timeout: None,
+            tls_config: None,
+            lookup_service,
+        }
+    }
+
     /// Set the how often, the client should probe for changes to  gRPC server endpoints.
     /// Default interval in seconds is 10.
     pub fn dns_probe_interval(self, interval: Duration) -> LoadBalancedChannelBuilder<T> {

--- a/ginepro/src/service_probe.rs
+++ b/ginepro/src/service_probe.rs
@@ -118,14 +118,14 @@ impl<Lookup: LookupService> GrpcServiceProbe<Lookup> {
 
         let remove_set: HashSet<SocketAddr> = self
             .endpoints
-            .difference(&endpoints)
-            .cloned()
+            .difference(endpoints)
+            .copied()
             .into_iter()
             .collect();
 
         let add_set: HashSet<SocketAddr> = endpoints
             .difference(&self.endpoints)
-            .cloned()
+            .copied()
             .into_iter()
             .collect();
 


### PR DESCRIPTION
Our `ServiceDefinition` cannot be processed by `DnsResolver`, so `LoadBalancedChannelBuilder::new_with_service` will always a `Err` and cannot apply `lookup_service` later.