### PR TITLE
Add hostname verification and try to resolve ips on build.

### DIFF
--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -23,6 +23,7 @@ tracing-futures = "0.2"
 http = "0.2"
 prost = "0.8"
 openssl = "0.10.34"
+thiserror = "1.0.29"
 
 [dev-dependencies]
 shared-proto = { path = "../shared_proto" }

--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -27,3 +27,4 @@ openssl = "0.10.34"
 [dev-dependencies]
 shared-proto = { path = "../shared_proto" }
 tests = { path = "../tests" }
+proptest = "1.0.0"

--- a/ginepro/examples/build_and_resolve.rs
+++ b/ginepro/examples/build_and_resolve.rs
@@ -1,0 +1,32 @@
+use std::convert::TryFrom;
+
+use anyhow::Context;
+use ginepro::{LoadBalancedChannel, ServiceDefinition};
+
+use shared_proto::pb::{echo_client::EchoClient, EchoRequest};
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // By using the constructor `build_and_resolve` the hostname is resolved once and ensures
+    // that LoadBalancedChannel will have a non-empty set of IPs to contact before the program
+    // starts.
+    let channel =
+        LoadBalancedChannel::builder(ServiceDefinition::try_from(("localhost", 5000_u16))?)
+            .await?
+            .build_and_resolve(std::time::Duration::from_secs(10))
+            .await
+            .context("failed to build LoadBalancedChannel")?;
+
+    // Use the channel created above to drive the communication in EchoClient.
+    let mut client = EchoClient::new(channel);
+
+    let request = tonic::Request::new(EchoRequest {
+        message: "hello".into(),
+    });
+
+    let response = client.unary_echo(request).await?;
+
+    println!("RESPONSE={:?}", response);
+
+    Ok(())
+}

--- a/ginepro/examples/client.rs
+++ b/ginepro/examples/client.rs
@@ -1,4 +1,6 @@
-use ginepro::LoadBalancedChannel;
+use std::convert::TryFrom;
+
+use ginepro::{LoadBalancedChannel, ServiceDefinition};
 
 use shared_proto::pb::{echo_client::EchoClient, EchoRequest};
 
@@ -6,10 +8,11 @@ use shared_proto::pb::{echo_client::EchoClient, EchoRequest};
 async fn main() -> Result<(), Box<dyn std::error::Error>> {
     // Create a load balanced channel that connects to localhost:5000.
     // Here the service discovery will update the set of servers every 5 seconds.
-    let channel = LoadBalancedChannel::builder(("localhost", 5000_u16))
-        .await?
-        .dns_probe_interval(std::time::Duration::from_secs(5))
-        .channel();
+    let channel =
+        LoadBalancedChannel::builder(ServiceDefinition::try_from(("localhost", 5000_u16))?)
+            .await?
+            .dns_probe_interval(std::time::Duration::from_secs(5))
+            .channel();
 
     // Use the channel created above to drive the communication in EchoClient.
     let mut client = EchoClient::new(channel);

--- a/ginepro/examples/client_tls.rs
+++ b/ginepro/examples/client_tls.rs
@@ -1,3 +1,5 @@
+use std::convert::TryInto;
+
 use ginepro::LoadBalancedChannel;
 use tonic::transport::Certificate;
 use tonic::transport::ClientTlsConfig;
@@ -16,7 +18,7 @@ async fn main() -> Result<(), Box<dyn std::error::Error>> {
 
     let tls = ClientTlsConfig::new().ca_certificate(ca);
 
-    let channel = LoadBalancedChannel::builder(("localhost", 5000_u16))
+    let channel = LoadBalancedChannel::builder(("localhost", 5000_u16).try_into()?)
         .await?
         .with_tls(tls)
         .dns_probe_interval(std::time::Duration::from_secs(5))

--- a/ginepro/src/dns_resolver.rs
+++ b/ginepro/src/dns_resolver.rs
@@ -35,14 +35,14 @@ impl LookupService for DnsResolver {
         &self,
         definition: &ServiceDefinition,
     ) -> Result<HashSet<SocketAddr>, anyhow::Error> {
-        match self.dns.lookup_ip(definition.hostname.as_ref()).await {
+        match self.dns.lookup_ip(definition.hostname()).await {
             Ok(lookup) => {
                 tracing::debug!("dns query expires in: {:?}", lookup.valid_until());
                 Ok(lookup
                     .iter()
                     .map(|ip_addr| {
                         tracing::debug!("result: ip {}", ip_addr);
-                        (ip_addr, definition.port).into()
+                        (ip_addr, definition.port()).into()
                     })
                     .collect())
             }

--- a/ginepro/src/lib.rs
+++ b/ginepro/src/lib.rs
@@ -8,9 +8,12 @@
 //! async fn main() {
 //!     use ginepro::LoadBalancedChannel;
 //!     use shared_proto::pb::tester_client::TesterClient;
+//!     use std::convert::TryInto;
 //!
 //!     // Create a load balanced channel with the default lookup implementation.
-//!     let load_balanced_channel = LoadBalancedChannel::builder(("my_hostname", 5000))
+//!     let load_balanced_channel = LoadBalancedChannel::builder(
+//!             ("my.hostname", 5000).try_into().expect("invalid hostname")
+//!         )
 //!         .await
 //!         .expect("failed to read system conf")
 //!         .channel();
@@ -43,8 +46,11 @@
 //! async fn main() {
 //!     use ginepro::LoadBalancedChannel;
 //!     use shared_proto::pb::tester_client::TesterClient;
+//!     use std::convert::TryInto;
 //!
-//!     let load_balanced_channel = LoadBalancedChannel::builder(("my_hostname", 5000))
+//!     let load_balanced_channel = LoadBalancedChannel::builder(
+//!             ("my.hostname", 5000).try_into().expect("invalid hostname")
+//!         )
 //!         .await
 //!         .expect("failed to read system conf")
 //!         .lookup_service(DummyLookupService)
@@ -60,8 +66,11 @@
 //! async fn main() {
 //!     use ginepro::{LoadBalancedChannel, LoadBalancedChannelBuilder};
 //!     use shared_proto::pb::tester_client::TesterClient;
+//!     use std::convert::TryInto;
 //!
-//!     let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("my_hostname", 5000))
+//!     let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(
+//!             ("my.hostname", 5000).try_into().expect("invalid hostname")
+//!         )
 //!         .await
 //!         .expect("failed to read system conf")
 //!         .dns_probe_interval(std::time::Duration::from_secs(3))
@@ -80,8 +89,11 @@
 //! async fn main() {
 //!     use ginepro::LoadBalancedChannel;
 //!     use shared_proto::pb::tester_client::TesterClient;
+//!     use std::convert::TryInto;
 //!
-//!     let load_balanced_channel = LoadBalancedChannel::builder(("my_hostname", 5000))
+//!     let load_balanced_channel = LoadBalancedChannel::builder(
+//!             ("my.hostname", 5000).try_into().expect("invalid hostname")
+//!         )
 //!         .await
 //!         .expect("failed to read system conf")
 //!         .timeout(std::time::Duration::from_secs(10))

--- a/ginepro/src/service_definition.rs
+++ b/ginepro/src/service_definition.rs
@@ -19,7 +19,7 @@ impl ServiceDefinition {
     pub fn from_parts<T: ToString>(hostname: T, port: u16) -> Result<Self, anyhow::Error> {
         let hostname = hostname.to_string();
 
-        trust_dns_resolver::Name::from_utf8(&hostname)
+        trust_dns_resolver::Name::from_ascii(&hostname)
             .map_err(anyhow::Error::from)
             .context("invalid 'hostname'")?;
 
@@ -57,7 +57,7 @@ mod test {
     }
 
     prop_compose! {
-        fn invalid_hostname()(s in "[^a-z.0-9*A-Z]+") -> String {
+        fn invalid_hostname()(s in "[^\\a-z.0-9*A-Z]+") -> String {
             s
         }
     }

--- a/ginepro/src/service_definition.rs
+++ b/ginepro/src/service_definition.rs
@@ -1,18 +1,73 @@
+use std::convert::TryFrom;
+
+use anyhow::Context;
+
 /// Defines a gRPC service with a `hostname` and a `port`.
 /// The hostname will be resolved to the concrete ips of the service servers.
 #[derive(Debug)]
 pub struct ServiceDefinition {
     /// The hostname of the service.
-    pub hostname: String,
+    hostname: String,
     /// The service port.
-    pub port: u16,
+    port: u16,
 }
 
-impl From<(&str, u16)> for ServiceDefinition {
-    fn from(service: (&str, u16)) -> Self {
-        Self {
-            hostname: service.0.to_string(),
-            port: service.1,
+impl ServiceDefinition {
+    /// Create a [`ServiceDefinition`] from a valid `hostname` and `port`.
+    ///
+    /// This function will fail is the `hostname` is not a valid domain name.
+    pub fn from_parts<T: ToString>(hostname: T, port: u16) -> Result<Self, anyhow::Error> {
+        let hostname = hostname.to_string();
+
+        trust_dns_resolver::Name::from_utf8(&hostname)
+            .map_err(anyhow::Error::from)
+            .context("invalid 'hostname'")?;
+
+        Ok(Self { hostname, port })
+    }
+
+    /// Get the `hostname` part of a `ServiceDefinition`.
+    pub fn hostname(&self) -> &str {
+        &self.hostname
+    }
+
+    /// Get the `port` part of a `ServiceDefinition`.
+    pub fn port(&self) -> u16 {
+        self.port
+    }
+}
+
+impl TryFrom<(&str, u16)> for ServiceDefinition {
+    type Error = anyhow::Error;
+
+    fn try_from((hostname, port): (&str, u16)) -> Result<Self, Self::Error> {
+        Self::from_parts(hostname, port)
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+
+    #[test]
+    fn invalid_hostname_shall_fail() {
+        let hostnames = vec!["127.0.0.1[][][]", "+.+.+"];
+
+        for hostname in hostnames {
+            assert!(
+                ServiceDefinition::from_parts(hostname, 5000).is_err(),
+                "{} is valid when it shouldn't",
+                hostname
+            );
+        }
+    }
+
+    #[test]
+    fn valid_hostname_shall_succeed() {
+        let hostnames = vec!["our.valid.fqdn", "mydns.com"];
+
+        for hostname in hostnames {
+            assert!(ServiceDefinition::from_parts(hostname, 5000).is_ok());
         }
     }
 }

--- a/tests/tests/all/service_probe.rs
+++ b/tests/tests/all/service_probe.rs
@@ -1,6 +1,6 @@
 use crate::lookup::TestDnsResolver;
 use crate::lookup::TesterImpl;
-use ginepro::LoadBalancedChannelBuilder;
+use ginepro::{LoadBalancedChannelBuilder, ServiceDefinition};
 use shared_proto::pb::pong::Payload;
 use shared_proto::pb::tester_client::TesterClient;
 use shared_proto::pb::Ping;
@@ -33,12 +33,14 @@ async fn load_balance_succeeds_with_churn() {
     let mut resolver = TestDnsResolver::default();
     let probe_interval = tokio::time::Duration::from_millis(3);
 
-    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("test", 5000))
-        .await
-        .expect("failed to init")
-        .lookup_service(resolver.clone())
-        .dns_probe_interval(probe_interval)
-        .channel();
+    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(
+        ServiceDefinition::from_parts("test", 5000).unwrap(),
+    )
+    .await
+    .expect("failed to init")
+    .lookup_service(resolver.clone())
+    .dns_probe_interval(probe_interval)
+    .channel();
     let mut client = TesterClient::new(load_balanced_channel);
 
     let servers: Vec<String> = (0..10).into_iter().map(|s| s.to_string()).collect();
@@ -109,13 +111,15 @@ async fn load_balance_succeeds_with_churn_with_tls_enabled() {
 
     let probe_interval = tokio::time::Duration::from_millis(3);
 
-    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("test", 5000))
-        .await
-        .expect("failed to init")
-        .lookup_service(resolver.clone())
-        .with_tls(config)
-        .dns_probe_interval(probe_interval)
-        .channel();
+    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(
+        ServiceDefinition::from_parts("test", 5000).unwrap(),
+    )
+    .await
+    .expect("failed to init")
+    .lookup_service(resolver.clone())
+    .with_tls(config)
+    .dns_probe_interval(probe_interval)
+    .channel();
     let mut client = TesterClient::new(load_balanced_channel);
 
     let servers: Vec<String> = (0..10).into_iter().map(|s| s.to_string()).collect();
@@ -168,12 +172,14 @@ async fn load_balance_happy_path_scenario_calls_all_endpoints() {
     let sender = Arc::new(Mutex::new(sender));
     let mut resolver = TestDnsResolver::default();
 
-    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("test", 5000))
-        .await
-        .expect("failed to init")
-        .lookup_service(resolver.clone())
-        .dns_probe_interval(tokio::time::Duration::from_millis(3))
-        .channel();
+    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(
+        ServiceDefinition::from_parts("test", 5000).unwrap(),
+    )
+    .await
+    .expect("failed to init")
+    .lookup_service(resolver.clone())
+    .dns_probe_interval(tokio::time::Duration::from_millis(3))
+    .channel();
     let mut client = TesterClient::new(load_balanced_channel);
 
     resolver
@@ -241,13 +247,15 @@ async fn connection_timeout_is_not_fatal() {
     let mut resolver = TestDnsResolver::default();
     let probe_interval = tokio::time::Duration::from_millis(3);
 
-    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(("test", 5000))
-        .await
-        .expect("failed to init")
-        .lookup_service(resolver.clone())
-        .timeout(tokio::time::Duration::from_millis(500))
-        .dns_probe_interval(probe_interval)
-        .channel();
+    let load_balanced_channel = LoadBalancedChannelBuilder::new_with_service(
+        ServiceDefinition::from_parts("test", 5000).unwrap(),
+    )
+    .await
+    .expect("failed to init")
+    .lookup_service(resolver.clone())
+    .timeout(tokio::time::Duration::from_millis(500))
+    .dns_probe_interval(probe_interval)
+    .channel();
     let mut client = TesterClient::new(load_balanced_channel);
 
     resolver


### PR DESCRIPTION
This PR tries to address the following:
* Make sure that the `hostname` part of the `ServiceDefinition` is valid by making the fields private and force constructing it through `from_parts` that includes the validation.
* Allow users to resolve the `ServiceDefinition` once before building the `LoadBalancedChannel` through a new method `build_and_resolve` that does the same as `channel` only that it will only succeed  if a call to `LookupService::resolve_service_endpoints` is successful.

Closes #20.