### PR TITLE
Update tonic to 0.11 using a version range

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,8 +1,9 @@
+name: CI # Continuous Integration
+
 on:
   push:
     branches: [main]
   pull_request:
-name: CI # Continuous Integration
 
 jobs:
 
@@ -125,10 +126,10 @@ jobs:
           toolchain: stable
           profile: minimal
           override: true
-      - name: Run cargo-tarpaulin
-        uses: actions-rs/tarpaulin@v0.1
-        with:
-          args: '--ignore-tests --out Lcov'
+      - name: Install cargo-tarpaulin
+        run: cargo install cargo-tarpaulin
+      - name: Check code coverage
+        run: cargo tarpaulin --ignore-tests --out Lcov
       - name: Upload to Coveralls
         # upload only if push
         if: ${{ github.event_name == 'push' }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -5,3 +5,5 @@ members = [
     "tests",
     "shared_proto"
 ]
+
+resolver = "2"

--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 http = "0.2"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
-tonic = { version = "0.10", features = ["tls"] }
+tonic = { version = ">=0.10,<0.12", features = ["tls"] }
 tower = { version = "0.4", default-features = false, features = ["discover"] }
 tracing = "0.1"
 trust-dns-resolver = "0.23"

--- a/ginepro/src/balanced_channel.rs
+++ b/ginepro/src/balanced_channel.rs
@@ -26,7 +26,7 @@ static GRPC_REPORT_ENDPOINTS_CHANNEL_SIZE: usize = 1024;
 /// Implements tonic [`GrpcService`] for a client-side load balanced [`Channel`] (using `The Power of
 /// Two Choices`).
 ///
-/// [`GrpcService`](tonic::client::GrpcService)
+/// [`GrpcService`]
 ///
 /// ```rust
 /// #[tokio::main]

--- a/shared_proto/Cargo.toml
+++ b/shared_proto/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 prost = "0.12"
-tonic = ">=0.10,<0.12"
+tonic = "0.11"
 
 [build-dependencies]
-tonic-build = ">=0.10,<0.12"
+tonic-build = "0.11"

--- a/shared_proto/Cargo.toml
+++ b/shared_proto/Cargo.toml
@@ -7,7 +7,7 @@ publish = false
 
 [dependencies]
 prost = "0.12"
-tonic = "0.10"
+tonic = ">=0.10,<0.12"
 
 [build-dependencies]
-tonic-build = "0.10"
+tonic-build = ">=0.10,<0.12"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ hyper = "0.14"
 openssl = "0.10"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.10", features = ["tls"] }
+tonic = { version = ">=0.10,<0.12", features = ["tls"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 tracing = { version = "0.1", features = ["attributes", "log"] }
@@ -22,4 +22,4 @@ tracing = { version = "0.1", features = ["attributes", "log"] }
 anyhow = "1"
 async-trait = "0.1"
 shared-proto = { path = "../shared_proto" }
-tonic-health = "0.10"
+tonic-health = ">=0.10,<0.12"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ hyper = "0.14"
 openssl = "0.10"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = ">=0.10,<0.12", features = ["tls"] }
+tonic = { version = "0.11", features = ["tls"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 tracing = { version = "0.1", features = ["attributes", "log"] }
@@ -22,4 +22,4 @@ tracing = { version = "0.1", features = ["attributes", "log"] }
 anyhow = "1"
 async-trait = "0.1"
 shared-proto = { path = "../shared_proto" }
-tonic-health = ">=0.10,<0.12"
+tonic-health = "0.11"

--- a/tests/src/test_server.rs
+++ b/tests/src/test_server.rs
@@ -6,11 +6,12 @@ use std::{
 };
 use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::wrappers::TcpListenerStream;
+use tonic::server::NamedService;
 use tonic::{
     body::BoxBody,
     transport::{
         server::{Router, Routes, Server},
-        NamedService, ServerTlsConfig,
+        ServerTlsConfig,
     },
 };
 use tower_layer::Layer;

--- a/tests/src/test_server.rs
+++ b/tests/src/test_server.rs
@@ -64,7 +64,7 @@ impl TestServer {
         Self::start_with_router(server_builder.add_service(service), address).await
     }
 
-    /// Bootstrap a tonic `TestServer`, with the a tonic [`Router`][tonic::transport::server::Router].
+    /// Bootstrap a tonic `TestServer`, with the a tonic [`Router`].
     /// This enables you to construct a `TestServer` with multiple services.
     ///
     /// ```


### PR DESCRIPTION
There is a new version of `tonic` available. This updates the various `Cargo.toml` files to accept a range of versions for that crate, allowing to update as needed.