### PR TITLE
chore: patch release `rocket`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## 0.7.2 (2024-04-22)
+
+### Fixed
+* Added support for IPv6 addresses
+
 ## 0.7.1 (2024-02-27)
 
 * Added support for **tonic** 0.11

--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ginepro"
-version = "0.7.1"
+version = "0.7.2"
 edition = "2021"
 description = "A client-side gRPC channel implementation for tonic"
 repository = "https://github.com/TrueLayer/ginepro"


### PR DESCRIPTION
## 0.7.2 (2024-04-22)

### Fixed
* Added support for IPv6 addresses