### PR TITLE
chore!: bump `tonic` to `0.12` for `hyper 1.0` ecosystem

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+
+* Update to **tonic** 0.12
+* Update to **prost** 0.13
+
 ## 0.7.2 (2024-04-22)
 
 ### Fixed

--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -12,10 +12,10 @@ readme = "../README.md"
 [dependencies]
 anyhow = "1"
 async-trait = "0.1"
-http = "0.2"
+http = "1"
 thiserror = "1"
 tokio = { version = "1", features = ["full"] }
-tonic = { version = ">=0.10,<0.12", features = ["tls"] }
+tonic = { version = "0.12", features = ["tls"] }
 tower = { version = "0.4", default-features = false, features = ["discover"] }
 tracing = "0.1"
 trust-dns-resolver = "0.23"

--- a/shared_proto/Cargo.toml
+++ b/shared_proto/Cargo.toml
@@ -6,8 +6,8 @@ edition = "2021"
 publish = false
 
 [dependencies]
-prost = "0.12"
-tonic = "0.11"
+prost = "0.13"
+tonic = "0.12"
 
 [build-dependencies]
-tonic-build = "0.11"
+tonic-build = "0.12"

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -9,11 +9,11 @@ publish = false
 ginepro = { path = "../ginepro" }
 
 futures = "0.3"
-hyper = "0.14"
+hyper = "1"
 openssl = "0.10"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.11", features = ["tls"] }
+tonic = { version = "0.12", features = ["tls"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 tracing = { version = "0.1", features = ["attributes", "log"] }
@@ -22,4 +22,4 @@ tracing = { version = "0.1", features = ["attributes", "log"] }
 anyhow = "1"
 async-trait = "0.1"
 shared-proto = { path = "../shared_proto" }
-tonic-health = "0.11"
+tonic-health = "0.12"

--- a/tests/src/test_server.rs
+++ b/tests/src/test_server.rs
@@ -1,19 +1,19 @@
 use futures::future::FutureExt;
-use hyper::{Body, Request, Response};
+use hyper::{Request, Response};
 use std::{
     convert::Infallible,
     time::{Duration, Instant},
 };
 use tokio::net::{TcpListener, TcpStream};
 use tokio_stream::wrappers::TcpListenerStream;
-use tonic::server::NamedService;
 use tonic::{
     body::BoxBody,
     transport::{
-        server::{Router, Routes, Server},
+        server::{Router, Server},
         ServerTlsConfig,
     },
 };
+use tonic::{server::NamedService, service::Routes};
 use tower_layer::Layer;
 use tower_service::Service;
 
@@ -45,7 +45,7 @@ impl TestServer {
         tls: Option<ServerTlsConfig>,
     ) -> Self
     where
-        S: Service<Request<Body>, Response = Response<BoxBody>, Error = Infallible>
+        S: Service<Request<BoxBody>, Response = Response<BoxBody>, Error = Infallible>
             + NamedService
             + Clone
             + Send
@@ -86,9 +86,10 @@ impl TestServer {
     pub async fn start_with_router<L, T>(router: Router<L>, address: T) -> TestServer
     where
         L: Layer<Routes> + Send + 'static,
-        L::Service: Service<Request<Body>, Response = Response<BoxBody>> + Clone + Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Future: Send + 'static,
-        <<L as Layer<Routes>>::Service as Service<Request<Body>>>::Error:
+        L::Service:
+            Service<Request<BoxBody>, Response = Response<BoxBody>> + Clone + Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Future: Send + 'static,
+        <<L as Layer<Routes>>::Service as Service<Request<BoxBody>>>::Error:
             Into<Box<dyn std::error::Error + Send + Sync>> + Send,
         T: Into<Option<String>>,
     {


### PR DESCRIPTION
Bump `tonic` to `0.12` and `prost` to `0.13` to align with the `hyper 1.0` ecosystem.