### PR TITLE
Use hickory-dns

### DIFF
--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.12", features = ["tls"] }
 tower = { version = "0.4", default-features = false, features = ["discover"] }
 tracing = "0.1"
-trust-dns-resolver = "0.23"
+hickory-resolver = { version = "0.24", features = ["tokio-runtime"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/ginepro/src/dns_resolver.rs
+++ b/ginepro/src/dns_resolver.rs
@@ -2,9 +2,9 @@
 
 use crate::{LookupService, ServiceDefinition};
 use anyhow::Context;
+use hickory_resolver::{system_conf, AsyncResolver, TokioAsyncResolver};
 use std::collections::HashSet;
 use std::net::SocketAddr;
-use trust_dns_resolver::{system_conf, AsyncResolver, TokioAsyncResolver};
 
 /// Implements [`LookupService`] by using DNS queries to lookup [`ServiceDefinition::hostname`].
 pub struct DnsResolver {

--- a/ginepro/src/service_definition.rs
+++ b/ginepro/src/service_definition.rs
@@ -17,7 +17,7 @@ impl ServiceDefinition {
     pub fn from_parts<T: ToString>(hostname: T, port: u16) -> Result<Self, anyhow::Error> {
         let hostname = hostname.to_string();
 
-        trust_dns_resolver::Name::from_ascii(&hostname)
+        hickory_resolver::Name::from_ascii(&hostname)
             .map_err(anyhow::Error::from)
             .context("invalid 'hostname'")?;
 

--- a/shared_proto/build.rs
+++ b/shared_proto/build.rs
@@ -6,6 +6,6 @@ fn main() -> Result<(), Box<dyn std::error::Error>> {
     tonic_build::configure()
         .build_server(true)
         .build_client(true)
-        .compile(&["proto/test.proto", "proto/echo.proto"], &["proto/"])?;
+        .compile_protos(&["proto/test.proto", "proto/echo.proto"], &["proto/"])?;
     Ok(())
 }


### PR DESCRIPTION
<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/ginepro/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/ginepro/blob/main/CHANGELOG.md
-->

In October 2023, `trust-dns` was rebranded to `hickory`, this incldued changing the crate names, `trust-dns-resolver` is unmaintained. See the project README https://github.com/bluejekyll/trust-dns?tab=readme-ov-file#trust-dns