### PR TITLE
Support for tonic 0.14

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Breaking changes
+- Update to to **tonic** 0.14
+
 ## [0.9.0](https://github.com/TrueLayer/ginepro/compare/ginepro-v0.8.2...ginepro-v0.8.1) - 2025-07-24
 
 ### Breaking changes

--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ginepro"
-version = "0.9.0"
+version = "0.10.0"
 edition = "2021"
 description = "A client-side gRPC channel implementation for tonic"
 repository = "https://github.com/TrueLayer/ginepro"
@@ -15,7 +15,7 @@ async-trait = "0.1"
 http = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
-tonic = { version = "0.13", features = ["tls-ring"] }
+tonic = { version = "0.14", features = ["tls-ring"] }
 tower = { version = "0.5", default-features = false, features = ["discover"] }
 tracing = "0.1"
 hickory-resolver = { version = "0.25", features = ["tokio"] }

--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.14", features = ["tls-ring"] }
 tower = { version = "0.5", default-features = false, features = ["discover"] }
 tracing = "0.1"
-hickory-resolver = { version = "0.25", features = ["tokio"] }
+hickory-resolver = { version = "0.26", features = ["tokio"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/ginepro/src/dns_resolver.rs
+++ b/ginepro/src/dns_resolver.rs
@@ -21,7 +21,7 @@ impl DnsResolver {
         opts.cache_size = 0;
 
         Ok(Self {
-            dns: builder.build(),
+            dns: builder.build()?,
         })
     }
 }

--- a/ginepro/src/service_definition.rs
+++ b/ginepro/src/service_definition.rs
@@ -17,7 +17,7 @@ impl ServiceDefinition {
     pub fn from_parts<T: ToString>(hostname: T, port: u16) -> Result<Self, anyhow::Error> {
         let hostname = hostname.to_string();
 
-        hickory_resolver::Name::from_ascii(&hostname)
+        hickory_resolver::proto::rr::Name::from_ascii(&hostname)
             .map_err(anyhow::Error::from)
             .context("invalid 'hostname'")?;
 

--- a/shared_proto/Cargo.toml
+++ b/shared_proto/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-prost = "0.13"
-tonic = "0.13"
+tonic-prost = "0.14"
+tonic = "0.14"
+prost = "0.14"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = "0.14"

--- a/shared_proto/build.rs
+++ b/shared_proto/build.rs
@@ -3,7 +3,7 @@
 //! tonic functionality.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
         .compile_protos(&["proto/test.proto", "proto/echo.proto"], &["proto/"])?;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -10,10 +10,10 @@ ginepro = { path = "../ginepro" }
 
 futures = "0.3"
 hyper = "1"
-openssl = "0.10"
+openssl = { version = "0.10", features = ["vendored"] }
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.13", features = ["tls-ring"] }
+tonic = { version = "0.14", features = ["tls-ring"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 tracing = { version = "0.1", features = ["attributes", "log"] }
@@ -22,4 +22,4 @@ tracing = { version = "0.1", features = ["attributes", "log"] }
 anyhow = "1"
 async-trait = "0.1"
 shared-proto = { path = "../shared_proto" }
-tonic-health = "0.13"
+tonic-health = "0.14"


### PR DESCRIPTION
## Add support to tonic 0.14

* Set tonic version to 0.14 
* Fix shared-proto for building proto with 0.14
* Updated version to 0.10.0 (I don't know if that suit the versioning policy)

Tests OK

Fix #68