### PR TITLE
Override origin on Endpoints

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Other
+- Changed endpoint construction to set origin for compatibility with SNI based servers.
+
 ## [0.9.0](https://github.com/TrueLayer/ginepro/compare/ginepro-v0.8.2...ginepro-v0.8.1) - 2025-07-24
 
 ### Breaking changes

--- a/ginepro/src/service_definition.rs
+++ b/ginepro/src/service_definition.rs
@@ -8,6 +8,8 @@ pub struct ServiceDefinition {
     hostname: String,
     /// The service port.
     port: u16,
+    /// Authority
+    authority: http::uri::Authority,
 }
 
 impl ServiceDefinition {
@@ -21,12 +23,24 @@ impl ServiceDefinition {
             .map_err(anyhow::Error::from)
             .context("invalid 'hostname'")?;
 
-        Ok(Self { hostname, port })
+        let authority = format!("{}:{}", hostname, port)
+            .parse()
+            .context("invalid 'hostname'")?;
+
+        Ok(Self {
+            hostname,
+            port,
+            authority,
+        })
     }
 
     /// Get the `hostname` part of a `ServiceDefinition`.
     pub fn hostname(&self) -> &str {
         &self.hostname
+    }
+
+    pub(crate) fn authority(&self) -> &http::uri::Authority {
+        &self.authority
     }
 
     /// Get the `port` part of a `ServiceDefinition`.

--- a/ginepro/src/service_probe.rs
+++ b/ginepro/src/service_probe.rs
@@ -252,7 +252,7 @@ fn create_origin(authority: http::uri::Authority) -> http::uri::Uri {
     let mut parts = http::uri::Parts::default();
     parts.scheme = Some(http::uri::Scheme::HTTP);
     parts.authority = Some(authority);
-    parts.path_and_query = Some(http::uri::PathAndQuery::from_static(""));
+    parts.path_and_query = Some(http::uri::PathAndQuery::from_static("/"));
     parts
         .try_into()
         .expect("Invalid URI. Impossible as all parts are present")

--- a/ginepro/src/service_probe.rs
+++ b/ginepro/src/service_probe.rs
@@ -34,6 +34,7 @@ where
     Lookup: LookupService,
 {
     service_definition: ServiceDefinition,
+    origin: http::uri::Uri,
     scheme: http::uri::Scheme,
     dns_lookup: Lookup,
     probe_interval: tokio::time::Duration,
@@ -70,8 +71,10 @@ impl<Lookup: LookupService> GrpcServiceProbe<Lookup> {
         config: GrpcServiceProbeConfig<Lookup>,
         endpoint_reporter: Sender<Change<SocketAddr, Endpoint>>,
     ) -> GrpcServiceProbe<Lookup> {
+        let origin = create_origin(config.service_definition.authority().clone());
         Self {
             service_definition: config.service_definition,
+            origin,
             dns_lookup: config.dns_lookup,
             probe_interval: config.probe_interval,
             endpoint_timeout: config.endpoint_timeout,
@@ -85,9 +88,15 @@ impl<Lookup: LookupService> GrpcServiceProbe<Lookup> {
 
     /// Enable tls for all endpoints.
     pub fn with_tls(self, tls_config: ClientTlsConfig) -> GrpcServiceProbe<Lookup> {
+        let mut parts = self.origin.into_parts();
+        parts.scheme = Some(http::uri::Scheme::HTTPS);
+        let origin = parts
+            .try_into()
+            .expect("Invalid URI. Impossible as all parts are present");
         Self {
             tls_config: Some(tls_config),
             scheme: http::uri::Scheme::HTTPS,
+            origin,
             ..self
         }
     }
@@ -215,7 +224,8 @@ impl<Lookup: LookupService> GrpcServiceProbe<Lookup> {
             .map_err(|err| {
                 tracing::warn!("endpoint creation error: {:?}", err);
             })
-            .ok()?;
+            .ok()?
+            .origin(self.origin.clone());
 
         if let Some(ref tls_config) = self.tls_config {
             endpoint = endpoint
@@ -236,4 +246,14 @@ impl<Lookup: LookupService> GrpcServiceProbe<Lookup> {
 
         Some(endpoint)
     }
+}
+
+fn create_origin(authority: http::uri::Authority) -> http::uri::Uri {
+    let mut parts = http::uri::Parts::default();
+    parts.scheme = Some(http::uri::Scheme::HTTP);
+    parts.authority = Some(authority);
+    parts.path_and_query = Some(http::uri::PathAndQuery::from_static(""));
+    parts
+        .try_into()
+        .expect("Invalid URI. Impossible as all parts are present")
 }


### PR DESCRIPTION
This change sets origin on Endpoints, such that the LoadBalancedChannel can be used with proxies which route to backend services based on origin.

My use case is to be able to use the same grpc client for both DNS based load balancing, and for accessing internal gRPC services through proxies (this is useful for testing).

<!-- Please explain the changes you made -->

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/ginepro/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/ginepro/blob/main/CHANGELOG.md
-->

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> Set the origin on gRPC endpoints (HTTP/HTTPS) derived from service authority to support SNI/proxy-based routing.
> 
> - **gRPC Endpoint Construction**:
>   - Set `origin` on `tonic::transport::Endpoint` in `ginepro/src/service_probe.rs`.
>   - Add `origin: http::uri::Uri` to `GrpcServiceProbe`; initialize from `ServiceDefinition.authority()` and switch scheme to HTTPS in `with_tls`.
>   - Add helper `create_origin(...)` to build the origin URI.
> - **Service Definition**:
>   - Add `authority: http::uri::Authority` to `ServiceDefinition`; compute in `from_parts` and expose `authority()` accessor.
> - **Changelog**:
>   - Note endpoint construction now sets origin for SNI-based servers.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 65032021e0e34575125c177660aa39b512368313. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->