### PR TITLE
fix: exit probe task promptly when client is dropped

### DIFF
--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -15,7 +15,7 @@ async-trait = "0.1"
 http = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
-tonic = { version = "0.13", features = ["tls-ring"] }
+tonic = { version = "0.14", features = ["tls-ring"] }
 tower = { version = "0.5", default-features = false, features = ["discover"] }
 tracing = "0.1"
 hickory-resolver = { version = "0.25", features = ["tokio"] }

--- a/ginepro/src/service_probe.rs
+++ b/ginepro/src/service_probe.rs
@@ -97,8 +97,6 @@ impl<Lookup: LookupService> GrpcServiceProbe<Lookup> {
     pub async fn probe(mut self) -> Result<(), anyhow::Error> {
         loop {
             // If the receiver is already gone (e.g. client dropped), exit promptly.
-            // Note: we must not rely solely on `ChangesetSenderClosed`, since when there is no
-            // endpoint change, we do not send anything and thus will not observe a closed channel.
             if self.endpoint_reporter.is_closed() {
                 return Ok(());
             }
@@ -242,63 +240,5 @@ impl<Lookup: LookupService> GrpcServiceProbe<Lookup> {
         }
 
         Some(endpoint)
-    }
-}
-
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-    use std::collections::HashSet;
-    use std::net::{IpAddr, Ipv4Addr, SocketAddr};
-    use tokio::sync::mpsc;
-    use tonic::transport::Endpoint;
-    use tower::discover::Change;
-
-    struct StaticLookup {
-        endpoints: HashSet<SocketAddr>,
-    }
-
-    #[async_trait::async_trait]
-    impl LookupService for StaticLookup {
-        async fn resolve_service_endpoints(
-            &self,
-            _definition: &ServiceDefinition,
-        ) -> Result<HashSet<SocketAddr>, anyhow::Error> {
-            Ok(self.endpoints.clone())
-        }
-    }
-
-    #[tokio::test]
-    async fn probe_exits_promptly_when_receiver_dropped_even_without_changes() {
-        let service_definition = ServiceDefinition::from_parts("localhost", 5000).unwrap();
-        let endpoints = HashSet::from([SocketAddr::new(IpAddr::V4(Ipv4Addr::LOCALHOST), 5000)]);
-        let dns_lookup = StaticLookup { endpoints };
-
-        let config = GrpcServiceProbeConfig {
-            service_definition,
-            dns_lookup,
-            probe_interval: tokio::time::Duration::from_secs(3600),
-            endpoint_timeout: None,
-            endpoint_connect_timeout: None,
-        };
-
-        let (tx, rx): (
-            mpsc::Sender<Change<SocketAddr, Endpoint>>,
-            mpsc::Receiver<Change<SocketAddr, Endpoint>>,
-        ) = mpsc::channel(8);
-
-        let mut probe = GrpcServiceProbe::new_with_reporter(config, tx);
-
-        // First probe commits the initial endpoint set.
-        probe.probe_once().await.unwrap();
-
-        // Drop receiver so subsequent iterations should terminate immediately.
-        drop(rx);
-
-        tokio::time::timeout(tokio::time::Duration::from_secs(2), probe.probe())
-            .await
-            .expect("probe should exit promptly after receiver is dropped")
-            .unwrap();
     }
 }

--- a/shared_proto/Cargo.toml
+++ b/shared_proto/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-prost = "0.13"
-tonic = "0.13"
+prost = "0.14"
+tonic = "0.14"
+tonic-prost = "0.14"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = "0.14"

--- a/shared_proto/build.rs
+++ b/shared_proto/build.rs
@@ -3,7 +3,7 @@
 //! tonic functionality.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
         .compile_protos(&["proto/test.proto", "proto/echo.proto"], &["proto/"])?;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ hyper = "1"
 openssl = "0.10"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.13", features = ["tls-ring"] }
+tonic = { version = "0.14", features = ["tls-ring"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 tracing = { version = "0.1", features = ["attributes", "log"] }
@@ -22,4 +22,4 @@ tracing = { version = "0.1", features = ["attributes", "log"] }
 anyhow = "1"
 async-trait = "0.1"
 shared-proto = { path = "../shared_proto" }
-tonic-health = "0.13"
+tonic-health = "0.14"


### PR DESCRIPTION
Instead of solely depending on the `ProbeError::ChangesetSenderClosed` to find out whether we need to exit the probe task, check if `self.endpoint_reporter.is_closed()`, so that we can promptly exit as long as the client is dropped (balance channel is closed) even if there's no change on the probing results.