### PR TITLE
Update hickory-resolver to v0.26

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.9.1](https://github.com/TrueLayer/ginepro/compare/ginepro-v0.9.1...ginepro-v0.9.0) - 2026-05-04
+
+### Other
+- Update to **hickory-resolver** 0.26
+
 ## [0.9.0](https://github.com/TrueLayer/ginepro/compare/ginepro-v0.8.2...ginepro-v0.8.1) - 2025-07-24
 
 ### Breaking changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,7 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [0.9.1](https://github.com/TrueLayer/ginepro/compare/ginepro-v0.9.1...ginepro-v0.9.0) - 2026-05-04
 
 ### Other
-- Update to **hickory-resolver** 0.26
+- Update to **hickory-resolver** 0.26 ([#72](https://github.com/TrueLayer/ginepro/pull/72))
 
 ## [0.9.0](https://github.com/TrueLayer/ginepro/compare/ginepro-v0.8.2...ginepro-v0.8.1) - 2025-07-24
 

--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ginepro"
-version = "0.9.0"
+version = "0.9.1"
 edition = "2021"
 description = "A client-side gRPC channel implementation for tonic"
 repository = "https://github.com/TrueLayer/ginepro"
@@ -18,7 +18,7 @@ tokio = { version = "1", features = ["full"] }
 tonic = { version = "0.13", features = ["tls-ring"] }
 tower = { version = "0.5", default-features = false, features = ["discover"] }
 tracing = "0.1"
-hickory-resolver = { version = "0.25", features = ["tokio"] }
+hickory-resolver = { version = "0.26", features = ["tokio"] }
 
 [dev-dependencies]
 proptest = "1"

--- a/ginepro/src/dns_resolver.rs
+++ b/ginepro/src/dns_resolver.rs
@@ -21,7 +21,7 @@ impl DnsResolver {
         opts.cache_size = 0;
 
         Ok(Self {
-            dns: builder.build(),
+            dns: builder.build()?,
         })
     }
 }

--- a/ginepro/src/lookup_service.rs
+++ b/ginepro/src/lookup_service.rs
@@ -10,7 +10,7 @@ use crate::ServiceDefinition;
 #[async_trait::async_trait]
 pub trait LookupService {
     /// Return a list of unique [`SocketAddr`] associated with the provided
-    /// [`ServiceDefinition`](crate::ServiceDefinition) containing the `hostname` `port` of the service.
+    /// [`ServiceDefinition`] containing the `hostname` `port` of the service.
     /// If no ip addresses were resolved, an empty HashSet is returned.
     async fn resolve_service_endpoints(
         &self,

--- a/ginepro/src/service_definition.rs
+++ b/ginepro/src/service_definition.rs
@@ -17,7 +17,7 @@ impl ServiceDefinition {
     pub fn from_parts<T: ToString>(hostname: T, port: u16) -> Result<Self, anyhow::Error> {
         let hostname = hostname.to_string();
 
-        hickory_resolver::Name::from_ascii(&hostname)
+        hickory_resolver::proto::rr::Name::from_ascii(&hostname)
             .map_err(anyhow::Error::from)
             .context("invalid 'hostname'")?;
 


### PR DESCRIPTION
Update `hickory-resolver` to v0.26 to fix the following advisories:
- [RUSTSEC-2026-0118](https://rustsec.org/advisories/RUSTSEC-2026-0118)
- [RUSTSEC-2026-0119](https://rustsec.org/advisories/RUSTSEC-2026-0119)

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/ginepro/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/ginepro/blob/main/CHANGELOG.md
-->
