### PR TITLE
remove coverage step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,31 +110,5 @@ jobs:
           command: publish
           args: --dry-run --manifest-path ginepro/Cargo.toml
 
-  coverage:
-    name: Code coverage
-    runs-on: ubuntu-latest
-    steps:
-      - name: Install Protoc
-        uses: arduino/setup-protoc@v1
-        with:
-          repo-token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Checkout repository
-        uses: actions/checkout@v2
-      - name: Install stable toolchain
-        uses: actions-rs/toolchain@v1
-        with:
-          toolchain: stable
-          profile: minimal
-          override: true
-      - name: Install cargo-tarpaulin
-        run: cargo install cargo-tarpaulin
-      - name: Check code coverage
-        run: cargo tarpaulin --ignore-tests --out Lcov
-      - name: Upload to Coveralls
-        # upload only if push
-        if: ${{ github.event_name == 'push' }}
-        uses: coverallsapp/github-action@master
-        with:
-          github-token: ${{ secrets.GITHUB_TOKEN }}
-          path-to-lcov: './lcov.info'
+
 

--- a/README.md
+++ b/README.md
@@ -5,7 +5,6 @@
 [![Crates.io](https://img.shields.io/crates/v/ginepro.svg)](https://crates.io/crates/ginepro)
 [![Docs.rs](https://docs.rs/ginepro/badge.svg)](https://docs.rs/ginepro)
 [![CI](https://github.com/TrueLayer/ginepro/workflows/CI/badge.svg)](https://github.com/TrueLayer/ginepro/actions)
-[![Coverage Status](https://coveralls.io/repos/github/TrueLayer/ginepro/badge.svg?branch=main&t=UWgSpm)](https://coveralls.io/github/TrueLayer/ginepro?branch=main)
 
 ## Overview
 


### PR DESCRIPTION
This PR removes the coverage job from CI

<!--
Please, make sure:
- you have read the contributing guidelines:
  https://github.com/TrueLayer/ginepro/blob/main/docs/CONTRIBUTING.md
- you have formatted the code using rustfmt:
  https://github.com/rust-lang/rustfmt
- you have checked that all tests pass, by running `cargo test --all`
- you have updated the changelog (if needed):
  https://github.com/TrueLayer/ginepro/blob/main/CHANGELOG.md
-->
