### PR TITLE
feat: widen tonic dependency to >=0.13, <0.15 to support tonic 0.14

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,5 +110,24 @@ jobs:
           command: publish
           args: --dry-run --manifest-path ginepro/Cargo.toml
 
-
+  tonic-0_13-check:
+    name: ginepro builds against tonic 0.13
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v2
+      - name: Install Rust
+        uses: actions-rs/toolchain@v1
+        with:
+          toolchain: stable
+          profile: minimal
+          override: true
+      - name: Check ginepro against the 0.13 lower bound
+        run: |
+          cd ginepro
+          cargo remove --dev proptest shared-proto tests
+          printf '\n[workspace]\n' >> Cargo.toml
+          cargo update -p tonic --precise 0.13.1
+          cargo check --no-default-features --features tls-ring
+          cargo check --no-default-features --features tls-aws-lc
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- Widen the `tonic` dependency to `>=0.13, <0.15` to support **tonic** 0.14 alongside 0.13.
+
 ## [0.9.3](https://github.com/TrueLayer/ginepro/compare/ginepro-v0.9.2...ginepro-v0.9.3) - 2026-05-15
 
 ### Added

--- a/ginepro/Cargo.toml
+++ b/ginepro/Cargo.toml
@@ -20,7 +20,7 @@ async-trait = "0.1"
 http = "1"
 thiserror = "2"
 tokio = { version = "1", features = ["full"] }
-tonic = { version = "0.13", default-features = false, features = ["router", "transport", "codegen", "prost"] }
+tonic = { version = ">=0.13, <0.15", default-features = false, features = ["router", "transport", "codegen"] }
 tower = { version = "0.5", default-features = false, features = ["discover"] }
 tracing = "0.1"
 hickory-resolver = { version = "0.26", features = ["tokio"] }

--- a/shared_proto/Cargo.toml
+++ b/shared_proto/Cargo.toml
@@ -6,8 +6,9 @@ edition = "2021"
 publish = false
 
 [dependencies]
-prost = "0.13"
-tonic = "0.13"
+prost = "0.14"
+tonic = "0.14"
+tonic-prost = "0.14"
 
 [build-dependencies]
-tonic-build = "0.13"
+tonic-prost-build = "0.14"

--- a/shared_proto/build.rs
+++ b/shared_proto/build.rs
@@ -3,7 +3,7 @@
 //! tonic functionality.
 
 fn main() -> Result<(), Box<dyn std::error::Error>> {
-    tonic_build::configure()
+    tonic_prost_build::configure()
         .build_server(true)
         .build_client(true)
         .compile_protos(&["proto/test.proto", "proto/echo.proto"], &["proto/"])?;

--- a/tests/Cargo.toml
+++ b/tests/Cargo.toml
@@ -13,7 +13,7 @@ hyper = "1"
 openssl = "0.10"
 tokio = { version = "1", features = ["full"] }
 tokio-stream = { version = "0.1", features = ["net"] }
-tonic = { version = "0.13", features = ["tls-ring"] }
+tonic = { version = "0.14", features = ["tls-ring"] }
 tower-layer = "0.3"
 tower-service = "0.3"
 tracing = { version = "0.1", features = ["attributes", "log"] }
@@ -22,4 +22,4 @@ tracing = { version = "0.1", features = ["attributes", "log"] }
 anyhow = "1"
 async-trait = "0.1"
 shared-proto = { path = "../shared_proto" }
-tonic-health = "0.13"
+tonic-health = "0.14"


### PR DESCRIPTION
## Support tonic 0.14 alongside 0.13

Addresses https://github.com/TrueLayer/ginepro/issues/68: Widens `ginepro`'s `tonic` requirement to `>=0.13, <0.15` so downstream users can build against either 0.13 or 0.14.

### Changes
- **`ginepro`**: widen `tonic` to `>=0.13, <0.15` and drop the `prost` feature (removed in 0.14; ginepro never used the prost codec, so it's a no-op on 0.13).
- **`shared_proto` / `tests`**: move to tonic 0.14, which splits prost codegen into separate crates (`tonic-build` -> `tonic-prost-build`, plus `tonic-prost`).
- **CI**: add a `tonic-0_13-check` job that compiles `ginepro` against the 0.13 lower bound, so both ends of the range are covered (0.14 via the existing test suite, 0.13 via this check).

### Verification
- `cargo check --workspace --all-features` passes on 0.14.
- `ginepro` compiles clean against tonic 0.13.1 with both `tls-ring` and `tls-aws-lc`.